### PR TITLE
Fix build and missing keys (#4)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 .idea
 .gradle
 build
+kotlin-js-store
+**/.DS_STORE
+**/*.swp

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,6 @@ group = "org.jitsi"
 version = "1.0-SNAPSHOT"
 
 repositories {
-    maven("https://kotlin.bintray.com/kotlin-js-wrappers/")
     mavenCentral()
     jcenter()
 }

--- a/src/main/kotlin/Endpoint.kt
+++ b/src/main/kotlin/Endpoint.kt
@@ -23,7 +23,7 @@ class Endpoint : RComponent<EpProps, EpState>() {
 
     override fun componentDidMount() {
         if (props.data != null) {
-            extractKeys(props.data!!.first())
+            extractKeys(props.data!!)
             val statsId = props.data!!.findFirstValueFor("statsId")
             if (statsId != undefined) {
                 setState {
@@ -32,17 +32,23 @@ class Endpoint : RComponent<EpProps, EpState>() {
             }
         }
         if (state.numericalKeys.isEmpty() && props.data != undefined) {
-            extractKeys(props.data!!.first())
+            extractKeys(props.data!!)
         }
     }
 
-    private fun extractKeys(data: dynamic) {
-        console.log("Extracting keys from ", data)
+    private fun extractKeys(dataList: List<dynamic>) {
+        console.log("Extracting keys from ", dataList)
         setState {
-            numericalKeys = getAllKeysWithValuesThat(data) { it is Number }
-            nonNumericalKeys = getAllKeysWithValuesThat(data) { it !is Number }
+            numericalKeys = dataList.flatMap { data ->
+                getAllKeysWithValuesThat(data) { it is Number }
+            }.toSet().toList()
+            nonNumericalKeys = dataList.flatMap { data ->
+                getAllKeysWithValuesThat(data) { it !is Number }
+            }.toSet().toList()
         }
     }
+
+    private fun extractKeys(data: dynamic) = extractKeys(listOf(data))
 
     override fun componentWillUnmount() {}
 


### PR DESCRIPTION
* Remove the bintray repo as it throws 502s and things work without it.

* fix: Extract keys from all samples instead of only the first one

This fixes a problem with keys that are not present in the first sample
missing (e.g. when an SSRC was added later).

This makes things slower, but I don't know how to aviod it!

* Add to gitignore